### PR TITLE
OFFAPPS-379 Fix multibrand cross domain hc article display

### DIFF
--- a/templates/list.hdbs
+++ b/templates/list.hdbs
@@ -20,7 +20,10 @@
         </ul>
       </div>
       <div class="entry-text">
-        <a href="{{url}}" data-id="{{id}}" title="{{title}}" class="main preview_link">{{title}}</a>
+        <a href="{{url}}" class="main preview_link" title="{{title}}"
+          data-id="{{id}}" data-subdomain="{{subdomain}}" data-article-body="{{body}}">
+          {{title}}
+        </a>
       </div>
     </div>
     {{#if agent_only}}


### PR DESCRIPTION
:koala:

Now cross domain hc articles are no longer fetched, the article body is pulled off search result straightaway
We don't have access to diff domain help center APIs so we will be missing access policies for cross domain articles.

/cc @zendesk/quokka

### Reference
- [JIRA OFFAPPS-379](https://zendesk.atlassian.net/browse/OFFAPPS-379)

### Risks
- ~~Cross domain articles don't show `private`~~ actually this never worked, because of admin access restriction on the endpoint