### PR TITLE
[ZD#1008173] Change HC search to use HC API endpoint for non-multibrand

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,8 +58,8 @@
       searchHelpCenter: function(query) {
         var locale = this.currentUser().locale(),
             limit =  this.queryLimit(),
-            url = this.isMultibrand? '/api/v2/search.json' : '/api/v2/help_center/articles/search.json',
-            query = this.isMultibrand? 'type:article ' + query : query;
+            url = this.isMultibrand ? '/api/v2/search.json' : '/api/v2/help_center/articles/search.json',
+            query = this.isMultibrand ? 'type:article ' + query : query;
         return {
           url: url,
           type: 'GET',

--- a/app.js
+++ b/app.js
@@ -57,14 +57,16 @@
 
       searchHelpCenter: function(query) {
         var locale = this.currentUser().locale(),
-            limit =  this.queryLimit();
+            limit =  this.queryLimit(),
+            url = this.isMultibrand? '/api/v2/search.json' : '/api/v2/help_center/articles/search.json',
+            query = this.isMultibrand? 'type:article ' + query : query;
         return {
-          url: '/api/v2/search.json',
+          url: url,
           type: 'GET',
           data: {
             per_page: limit,
             locale:   locale,
-            query:    'type:article ' + query
+            query:    query
           }
         };
       },


### PR DESCRIPTION
Currently, the HC search always uses the Core API search endpoint, which will not return results from a restricted HC. The HC API endpoint will return such results, however it looks like that endpoint was previously removed for multi brand compatibility (PR #41).

This change should allow single-brand accounts to search restricted HCs without breaking multi brand support.

per @maximeprades, CC: @svizzari, @danielbreves, @princemaple, @angiesaurus 