### PR TITLE
Update appendComment() method to include richtext option

### DIFF
--- a/app.js
+++ b/app.js
@@ -114,6 +114,7 @@
 
     settingsDone: function(data) {
       this.useMarkdown = data.settings.tickets.markdown_ticket_comments;
+      this.useRichText = data.settings.tickets.rich_text_comments;
     },
 
     hcArticleLocaleContent: function(data) {
@@ -284,16 +285,20 @@
       event.preventDefault();
       var content = "";
 
+      var title = event.target.title;
+      var link = event.target.href;
+
       if (this.useMarkdown) {
-        var title = event.target.title;
-        var link = event.target.href;
         content = helpers.fmt("[%@](%@)", title, link);
+      }
+      else if (this.useRichText){
+        content = helpers.fmt("<a href='%@' target='_blank'>%@</a>", link, title);
       }
       else {
         if (this.setting('include_title')) {
-          content = event.target.title + ' - ';
+          content = title + ' - ';
         }
-        content += event.currentTarget.href;
+        content += link;
       }
       return this.appendToComment(content);
     },
@@ -320,8 +325,7 @@
     },
 
     appendToComment: function(text){
-      var old_text = _.isEmpty(this.comment().text()) ? '' : this.comment().text() + '\n';
-      return this.comment().text( old_text + text);
+      return this.useRichText ? this.comment().appendHtml(text) : this.comment().appendText(text);
     },
 
     stop_words: _.memoize(function(){


### PR DESCRIPTION
:koala:

:warning: **DO NOT MERGE UNTIL [THIS PR](https://github.com/zendesk/zendesk_console/pull/9560) HAS BEEN DEPLOYED TO PRODUCTION.** :warning:

This PR address an issue where HC links added from the Answer Suggestion app were not being formatted correctly when using the WYSIWYG editor. It uses new API endpoints introduced in [this PR](https://github.com/zendesk/zendesk_console/pull/9560)

/cc @zendesk/quokka

### References
 - Jira link: https://zendesk.atlassian.net/browse/AI-4138

### Risks
 - None