### PR TITLE
Escape special chars in title and link when inserting into rich text …

### DIFF
--- a/app.js
+++ b/app.js
@@ -292,7 +292,7 @@
         content = helpers.fmt("[%@](%@)", title, link);
       }
       else if (this.useRichText){
-        content = helpers.fmt("<a href='%@' target='_blank'>%@</a>", link, title);
+        content = helpers.fmt("<a href='%@' target='_blank'>%@</a>", _.escape(link), _.escape(title));
       }
       else {
         if (this.setting('include_title')) {


### PR DESCRIPTION
:koala:

Added code to espace special characters when inserting content into rich text editor.

/cc @zendesk/quokka, @ggrossman, @thilgen

### References
 - Jira link: https://zendesk.atlassian.net/browse/OFFAPPS-608

### Risks
 - None