### PR TITLE
updated useRichText param to use comment api rather than account setting

### DIFF
--- a/app.js
+++ b/app.js
@@ -116,7 +116,7 @@
 
     settingsDone: function(data) {
       this.useMarkdown = data.settings.tickets.markdown_ticket_comments;
-      this.useRichText = data.settings.tickets.rich_text_comments;
+      this.useRichText = this.ticket().comment().useRichText();
     },
 
     hcArticleLocaleContent: function(data) {

--- a/app.js
+++ b/app.js
@@ -105,6 +105,8 @@
     },
 
     initialize: function(){
+      this.useRichText = this.ticket().comment().useRichText();
+
       this.ajax('settings').then(function() {
         if (_.isEmpty(this.ticket().subject())) {
           return this.switchTo('no_subject');
@@ -116,7 +118,6 @@
 
     settingsDone: function(data) {
       this.useMarkdown = data.settings.tickets.markdown_ticket_comments;
-      this.useRichText = this.ticket().comment().useRichText();
     },
 
     hcArticleLocaleContent: function(data) {


### PR DESCRIPTION
:bread:

Based on advice from @roseleaf in [ticket #1365668](https://support.zendesk.com/agent/tickets/1365668)

/cc @zendesk/vegemite 

### References
 - Jira link: n/a

### Risks
 - None