### PR TITLE
[OFFAPPS-663] Updated nb_entries setting to be required and default to 10

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,9 @@
   "parameters": [
     {
       "name": "nb_entries",
-      "type": "number"
+      "type": "number",
+      "default": 10,
+      "required": true
     },
     {
       "name": "custom_host",


### PR DESCRIPTION
:koala:

Currently the "number of entries" setting is not required. If the value is left blank in the settings page `null` is sent to the search endpoint which results in an error.

![](http://cl.ly/121s0v1O3K30/Image%202016-02-02%20at%2010.49.50%20AM.png)

/cc @zendesk/vegemite 

### References
 - Jira link: https://zendesk.atlassian.net/browse/OFFAPPS-663

### Risks
 - None