### PR TITLE
fix first request with multibrand after app init

### DIFF
--- a/app.js
+++ b/app.js
@@ -134,9 +134,9 @@
 
         if (this.isMultibrand) { this.getBrandsDone(brandsData); }
         if (this.isMultilocale) { this.getLocalesDone(localeData); }
-      }.bind(this));
 
-      this.initialize();
+        this.initialize();
+      }.bind(this));
     },
 
     initialize: function(){


### PR DESCRIPTION
"getBrands" and "search" from initialize function run In async. Sometimes it makes a problem with this.isMultibrand in searchHelpCenter function. I think it is right to run first "search" request  after the completion of getBrands request.