### PR TITLE
add form for search so that we can track it

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,10 +25,7 @@
       //the dragend event when users are using Markdown or text.
       'dragend': function(event){ if (!this.useRichText) this.copyLink(event); },
       'click .toggle-app': 'toggleAppContainer',
-      'keyup .custom-search input': function(event){
-        if (event.keyCode === 13) { return this.processSearchFromInput(); }
-      },
-      'click .custom-search .search-btn': 'processSearchFromInput'
+      'submit .custom-search': 'processSearchFromInput'
     },
 
     requests: {
@@ -253,6 +250,7 @@
     processSearchFromInput: function() {
       var query = this.removePunctuation(this.$('.custom-search input').val());
       if (query && query.length) { this.search(query); }
+      return false;
     },
 
     baseUrl: function() {

--- a/templates/layout.hdbs
+++ b/templates/layout.hdbs
@@ -6,10 +6,10 @@
 </header>
 
 <div class="app-container">
-  <div class="input-append custom-search">
+  <form class="input-append custom-search">
     <input type="text" placeholder="{{t "layout.placeholder_text"}}">
-    <button class="search-btn btn" type="button">{{t "layout.search_button"}}</button>
-  </div>
+    <button class="search-btn btn" type="submit">{{t "layout.search_button"}}</button>
+  </form>
 
   <section data-main/>
 


### PR DESCRIPTION
@zendesk/vegemite 
### Purpose
Currently we can’t track the times there is a user-initiated HC search because this app searches automatically on load. Short of adding metrics to the app itself, this would let us at least watch submit in Heap

Not sure why this wasn't a form before